### PR TITLE
Fixed typo in samba command block

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -76,7 +76,7 @@ virsh <command> <domain>
 ## Samba
 
 ```bash
-/etc/rd.d/rc.samba <command>
+/etc/rc.d/rc.samba <command>
 ```
 
 **Available commands:**


### PR DESCRIPTION
should be rc.d instead of rd.d